### PR TITLE
Potential fix for code scanning alert no. 58: Clear-text logging of sensitive information

### DIFF
--- a/utils/db_manager.py
+++ b/utils/db_manager.py
@@ -136,7 +136,7 @@ class DBManager:
             logger.error(f"Requête: {query}")
             if params:
                 sanitized_params = self._sanitize_sensitive_data(params)
-                logger.error(f"Paramètres: {sanitized_params}")
+                # Sensitive parameters are sanitized but not logged to avoid exposure.
             return False
 
     def initialize_database(self):

--- a/utils/db_manager.py
+++ b/utils/db_manager.py
@@ -25,6 +25,15 @@ class DBManager:
             import logging
             self.logger = logging.getLogger(__name__)
 
+    def _sanitize_sensitive_data(self, data):
+        """
+        Remplace les données sensibles par des valeurs masquées.
+        """
+        if isinstance(data, dict):
+            sensitive_keys = {'smtp_password', 'password'}
+            return {key: ('***' if key in sensitive_keys else value) for key, value in data.items()}
+        return data
+
     def get_connection(self):
         if self.db_type == 'sqlite':
             # Une meilleure approche pour SQLite dans un environnement multi-thread
@@ -126,7 +135,8 @@ class DBManager:
             logger.error(f"Erreur lors de l'exécution de la requête: {str(e)}")
             logger.error(f"Requête: {query}")
             if params:
-                logger.error(f"Paramètres: {params}")
+                sanitized_params = self._sanitize_sensitive_data(params)
+                logger.error(f"Paramètres: {sanitized_params}")
             return False
 
     def initialize_database(self):


### PR DESCRIPTION
Potential fix for [https://github.com/toto789520/GLPIbis/security/code-scanning/58](https://github.com/toto789520/GLPIbis/security/code-scanning/58)

To fix the issue, sensitive data such as passwords should be excluded or masked before being logged. Specifically, the `params` variable should be sanitized to remove or obfuscate sensitive information before logging. This can be achieved by identifying sensitive keys (e.g., `smtp_password`) and replacing their values with a placeholder (e.g., `***`).

**Steps to implement the fix:**
1. Add a helper function to sanitize sensitive data in dictionaries, replacing sensitive values with placeholders.
2. Use this helper function to sanitize `params` before logging it in the `execute_query` method.

**Required changes:**
- Add a helper function to sanitize sensitive data.
- Update the logging statement on line 129 in `utils/db_manager.py` to use the sanitization function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
