### PR TITLE
Potential fix for code scanning alert no. 56: Clear-text logging of sensitive information

### DIFF
--- a/onekey/auth.py
+++ b/onekey/auth.py
@@ -69,9 +69,9 @@ def register_user(name, age, tel, email, password, role='user'):
             raise ValueError("Un utilisateur avec cet email existe déjà")
           # Valider le mot de passe
         if not validate_password(password):
-            app_logger.debug(f"Validation du mot de passe échouée pour {email}")
+            app_logger.debug("Validation du mot de passe échouée")
             raise ValueError("Le mot de passe ne respecte pas les critères de complexité")
-        app_logger.debug(f"Validation du mot de passe réussie pour {email}")
+        app_logger.debug("Validation du mot de passe réussie")
         
         # Hasher le mot de passe
         ph = argon2.PasswordHasher()


### PR DESCRIPTION
Potential fix for [https://github.com/toto789520/GLPIbis/security/code-scanning/56](https://github.com/toto789520/GLPIbis/security/code-scanning/56)

To fix the issue, we should avoid logging sensitive information such as email addresses during password validation. Instead, we can log generic messages that do not include user-specific data. This ensures that the logs remain useful for debugging while protecting sensitive information.

The best way to fix this is to replace the debug log statements with generic messages that do not include the `email` parameter. For example, instead of logging `f"Validation du mot de passe réussie pour {email}"`, we can log `"Validation du mot de passe réussie"`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
