### PR TITLE
Potential fix for code scanning alert no. 51: Flask app is run in debug mode

### DIFF
--- a/app.py
+++ b/app.py
@@ -568,7 +568,9 @@ if __name__ == '__main__':
 
         atexit.register(cleanup)
         
-        app.run(debug=True, host='127.0.0.1', port=5000)
+        # Dynamically set debug mode based on the environment
+        debug_mode = os.environ.get('FLASK_ENV', 'production') == 'development'
+        app.run(debug=debug_mode, host='127.0.0.1', port=5000)
         
     except Exception as e:
         app_logger.error(f"Erreur fatale: {e}")


### PR DESCRIPTION
Potential fix for [https://github.com/toto789520/GLPIbis/security/code-scanning/51](https://github.com/toto789520/GLPIbis/security/code-scanning/51)

To address the issue, the code should dynamically set the `debug` parameter based on the environment in which the application is running. This can be achieved by introducing an environment variable (e.g., `FLASK_ENV`) or a configuration file to distinguish between development and production environments. The `debug` parameter should only be set to `True` in development mode.

**Steps to fix:**
1. Add logic to check the environment (e.g., using `os.environ` or a configuration file).
2. Set `debug=True` only if the environment is `development`.
3. Ensure that the default behavior is `debug=False` for production environments.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
