### PR TITLE
Potential fix for code scanning alert no. 52: Flask app is run in debug mode

### DIFF
--- a/debug_app.py
+++ b/debug_app.py
@@ -4,7 +4,7 @@ import os
 app = Flask(__name__)
 
 # Configuration de débogage
-app.config['DEBUG'] = True
+app.config['DEBUG'] = os.environ.get('FLASK_ENV') == 'development'
 
 # Vérification des chemins
 print(f"Dossier de l'application: {app.root_path}")
@@ -74,4 +74,4 @@ def test():
     """
 
 if __name__ == '__main__':
-    app.run(debug=True, port=5000)
+    app.run(debug=app.config['DEBUG'], port=5000)


### PR DESCRIPTION
Potential fix for [https://github.com/toto789520/GLPIbis/security/code-scanning/52](https://github.com/toto789520/GLPIbis/security/code-scanning/52)

To fix the issue, we need to ensure that the Flask application does not run in debug mode in production. This can be achieved by using environment-based configuration to determine whether debug mode should be enabled. Specifically:
1. Use the `os.environ` module to check for an environment variable (e.g., `FLASK_ENV`) to determine the environment (`development` or `production`).
2. Set `debug=True` only if the environment is `development`.
3. Remove the hardcoded `debug=True` in the `app.run()` call and replace it with a conditional check based on the environment.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
